### PR TITLE
made MIDA LUT an external csv

### DIFF
--- a/src/pedsilicoICH/ground_truth_definition/MIDA_v1.csv
+++ b/src/pedsilicoICH/ground_truth_definition/MIDA_v1.csv
@@ -1,0 +1,117 @@
+﻿MIDA_ID,c1,c2,c3,MIDA_material,HU,Source
+1,0,0.988235,1,Dura,50,
+2,1,0.780392,0,Cerebellum Gray Matter,9999,
+3,0.658824,1,1,Pineal Body,50,
+4,0,0,1,Amygdala,9999,
+5,1,0.423529,1,Hippocampus,9999,
+6,0.368627,0.588235,0.54902,CSF Ventricles,15,
+7,0,0.384314,0.466667,Caudate Nucleus,9999,
+8,0.823529,0.54902,1,Putamen,9999,
+9,0.713726,0.121569,0.341176,Cerebellum White Matter,8888,
+10,0.521569,0.521569,0.533333,Brain Gray Matter,9999,
+11,0.807843,0,1,Brainstem Midbrain,9999,
+12,1,1,1,Brain White Matter,8888,
+13,0.917647,0.521569,0,Spinal Cord,9999,
+14,1,1,0,Brainstem Pons,9999,
+15,0.686275,1,0.423529,Brainstem Medulla,9999,
+16,0.890196,0.905882,0,Nucleus Accumbens,9999,
+17,0.894118,0.796078,1,Globus Pallidus,9999,
+18,0,1,0,Optic Tract,8888,
+19,1,0.686275,0,Hypophysis or Pituitary Gland,9999,
+20,1,1,0,Mammillary Body,9999,
+21,0.890196,0.356863,0.505882,Hypothalamus,9999,
+22,0.72549,0.807843,1,Commissura (Anterior),8888,
+23,0.85098,0,0.247059,Commissura (Posterior),8888,
+24,1,0,0,Blood Arteries,37,
+25,0,0,1,Blood Veins,37,
+26,0,0,0,Air Internal - Ethmoidal Sinus,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+27,0,0,0,Air Internal - Frontal Sinus,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+28,0,0,0,Air Internal - Maxillary Sinus,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+29,0,0,0,Air Internal - Sphenoidal Sinus,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+30,0,0,0.54902,Air Internal - Mastoid,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+31,0,0,0,Air Internal - Nasal/Pharynx,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+32,0.411765,0,0,CSF General,15,
+33,0.905882,0.45098,1,Ear Cochlea,50,TBD
+34,1,0.223529,0.211765,Ear Semicircular Canals,50,TBD
+35,0,0.913725,0.843137,Ear Auricular Cartilage (Pinna),50,TBD
+36,0,0.411765,0,Mandible,700,TBD
+37,0.588235,0,0.301961,Mucosa,50,TBD
+38,0.45098,0.776471,0.12549,Muscle (General),55,
+39,0.85098,0.713726,1,Nasal Septum (Cartilage),50,TBD
+40,1,1,0.588235,Skull,900,
+41,1,0,1,Teeth,400,
+42,1,0.588235,0,Tongue,55,TBD
+43,0.690196,0.478431,1,Adipose Tissue,-120,
+44,0,0.988235,0.368627,Vertebra - C1 (atlas),400,
+45,0.384314,0.823529,1,Vertebra - C2 (axis),400,
+46,1,0,0.988235,Vertebra - C3,400,
+47,0.203922,0.466667,0.368627,Vertebra - C4,400,
+48,0,0.137255,0.862745,Vertebra - C5,400,
+49,1,0.603922,0.780392,Intervertebral Discs,50,TBD
+50,0,0,0,Background,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+51,1,0.72549,0.564706,Epidermis/Dermis,50,TBD
+52,0.745098,0,0,Skull Diplo ,800,
+53,0.309804,0,0.294118,Skull Inner Table,1000,
+54,0,0.662745,0.843137,Skull Outer Table,1000,
+55,0,0,1,Eye Lens,90,Looking at real subject
+56,1,1,1,Eye Retina/Choroid/Sclera,55,Looking at real subject
+57,0,0.576471,0.356863,Eye Vitreous,10,Looking at real subject
+58,0.576471,0,0.164706,Eye Cornea,55,Looking at real subject
+59,0.494118,0.741176,1,Eye Aqueous,90,Looking at real subject
+60,1,0.337255,0,Muscle - Platysma,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+61,1,0,0.396078,Tendon - Galea Aponeurotica,95,Imaging of Tendons and Bursae | Radiology Key
+62,0.521569,0.239216,0.352941,Subcutaneous Adipose Tissue,-120,
+63,1,0.196078,0,Muscle - Temporalis/Temporoparietalis,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+64,1,0.67451,0.494118,Muscle - Occipitiofrontalis - Frontal Belly,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+65,0.815686,0.352941,0.423529,Muscle - Lateral Pterygoid,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+66,1,0.717647,0,Muscle - Masseter,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+67,1,0.45098,0.254902,Muscle - Splenius Capitis,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+68,0.733333,0.098039,0.294118,Muscle - Sternocleidomastoid,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+69,0.788235,0.635294,1,Muscle - Occipitiofrontalis - Occipital Belly,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+70,0.282353,0.396078,0.407843,Muscle - Trapezius,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+71,1,0.309804,0.309804,Muscle - Mentalis,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+72,0.533333,0.603922,0.913725,Muscle - Depressor Anguli Oris,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+73,1,0.67451,0,Muscle - Depressor Labii,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+74,0,0.466667,0.913725,Muscle - Nasalis,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+75,1,0.54902,0.647059,Muscle - Orbicularis Oris,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+76,0.945098,0.12549,0.254902,Muscles - Procerus,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+77,0,0.407843,0,Muscle - Levator Labii Superioris,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+78,0,0.564706,0.717647,Muscle - Zygomaticus Major,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+79,0.211765,0.776471,0.533333,Muscle - Orbicularis Oculi,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+80,0.294118,0,0,Muscle - Levator Scapulae,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+81,0.843137,0.619608,0.239216,Muscle - Medial Pterygoid,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+82,1,0.239216,0.282353,Muscle - Zygomaticus Minor,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+83,0.521569,0.494118,0.635294,Muscles - Risorius,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+84,1,0.435294,0.098039,Muscle - Buccinator,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+85,1,1,1,Ear Auditory Canal,50,
+86,0.901961,0.309804,0.266667,Ear Pharyngotympanic Tube,50,
+87,0.760784,0.533333,0,Hyoid Bone,130,Hyoid bone development: An assessment of optimal CT scanner parameters and 3D volume rendering techniques - PMC
+88,0.858824,0.929412,0.619608,Submandibular Gland,50,
+89,0.505882,0.423529,0.521569,Parotid Gland,50,
+90,1,0.54902,0.45098,Sublingual Gland,50,
+91,0.619608,0.717647,1,Muscle - Superior Rectus,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+92,1,0.67451,0.168627,Muscle - Medial Rectus,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+93,0.266667,0.282353,0.576471,Muscle - Lateral Rectus,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+94,0.945098,0,0.745098,Muscle - Inferior Rectus,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+95,0,1,1,Muscle - Superior Oblique,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+96,1,1,0,Muscle - Inferior Oblique,50,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+97,0,0,0,Air Internal - Oral Cavity,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
+98,0,0.282353,0.043137,Tendon - Temporalis Tendon,95,Imaging of Tendons and Bursae | Radiology Key
+99,0,0.847059,0,Substantia Nigra,9999,
+100,0.360784,0,0.862745,Cerebral Peduncles,8888,
+101,1,0,0,Optic Chiasm,8888,
+102,0,0.984314,0,Cranial Nerve I - Olfactory,9999,
+103,0.25098,0.568627,0.639216,Cranial Nerve II - Optic,9999,
+104,0,0,1,Cranial Nerve III - Oculomotor,9999,
+105,0.65098,0.196078,0.458824,Cranial Nerve IV - Trochlear,9999,
+106,0.458824,0.290196,0.792157,Cranial Nerve V - Trigeminal,9999,
+107,0.929412,0,0.929412,Cranial Nerve V2 - Maxillary Division,9999,
+108,1,0.890196,0,Cranial Nerve V3 - Mandibular Division,9999,
+109,1,0,1,Cranial Nerve VI - Abducens,9999,
+110,0.513726,0.803922,0.556863,Cranial Nerve VII - Facial,9999,
+111,0.623529,1,1,Cranial Nerve VIII - Vestibulocochlear,9999,
+112,0,1,0,Cranial Nerve IX - Glossopharyngeal,9999,
+113,0.65098,0.376471,0.596078,Cranial Nerve X - Vagus,9999,
+114,0.082353,0.458824,0.207843,Cranial Nerve XI - Accessory,9999,
+115,1,1,0,Cranial Nerve XII - Hypoglossal,9999,
+116,0,0,1,Thalamus,9999,

--- a/src/pedsilicoICH/ground_truth_definition/phantoms.py
+++ b/src/pedsilicoICH/ground_truth_definition/phantoms.py
@@ -5,6 +5,7 @@ module for working with phantoms
 from pathlib import Path
 from io import StringIO
 
+import os
 import numpy as np
 import nibabel as nib
 import pandas as pd
@@ -381,7 +382,7 @@ class MIDA_Head(HeadPhantom):
     def __init__(self, phantom_dir, csf_HU=10, gm_HU=40, wm_HU=30,
                  skull_HU=1000, shape=None):
         super().__init__(phantom_dir)
-        self.age = 39  # median american age
+        self.age = 38  # median american age
         self.csf_HU = csf_HU
         self.gm_HU = gm_HU
         self.wm_HU = wm_HU
@@ -391,6 +392,9 @@ class MIDA_Head(HeadPhantom):
 
         img = nib.load(self.phantom_dir/'MIDA_v1.nii')
         self._phantom = np.array(img.get_fdata()).transpose(1, 0, 2)[::-1]
+
+        header = img.header
+        self.dx, self.dy, self.dz = header['pixdim'][1:4]
 
         original_shape = self._phantom.shape
         if shape:
@@ -403,109 +407,26 @@ class MIDA_Head(HeadPhantom):
         self.nz, self.nx, self.ny = shape
 
     def _load_material_LUT(self):
-
-        with open(self.phantom_dir / 'MIDA_v1.txt', 'rb') as data:
-            df = pd.read_csv(StringIO(data.read().decode(errors='replace')), sep='\t', names=['grayscale','c1', 'c2', 'c3', 'material'])
-            material_lut = df.iloc[:-8] # read in the material look up table from the top of the txt file
-            image_size_info = df.iloc[-8:, :2].set_index('grayscale').T
-            self.nx, self.ny, self.nz = int(image_size_info.nx.item()), int(image_size_info.ny.item()), int(image_size_info.nz.item())
-            self.dx, self.dy, self.dz = image_size_info.dx.item()*1000, image_size_info.dy.item()*1000, image_size_info.dz.item()*1000
-
-        # BRAIN TISSUE / FLUIDS
-        material_lut.loc[material_lut.material == 'Cerebellum Gray Matter', 'grayscale'] = 10
-        material_lut.loc[material_lut.material == 'Cerebellum  Gray Matter', 'xcist material'] = 'gray_matter'
-        material_lut.loc[material_lut.material == 'Cerebellum  Gray Matter', 'CT Number [HU]'] = self.gm_HU
-
-        material_lut.loc[material_lut.material == 'Brain Gray Matter', 'grayscale'] = 10
-        material_lut.loc[material_lut.material == 'Brain Gray Matter', 'xcist material'] = 'gray_matter'
-        material_lut.loc[material_lut.material == 'Brain Gray Matter', 'CT Number [HU]'] = self.gm_HU
-
-        material_lut.loc[material_lut.material == 'Thalamus', 'grayscale'] = 116
-        material_lut.loc[material_lut.material == 'Thalamus', 'xcist material'] = 'gray_matter'
-        material_lut.loc[material_lut.material == 'Thalamus', 'CT Number [HU]'] = self.gm_HU
-
-        material_lut.loc[material_lut.material == 'Cerebellum White Matter', 'grayscale'] = 12
-        material_lut.loc[material_lut.material == 'Cerebellum White Matter', 'xcist material'] = 'white_matter'
-        material_lut.loc[material_lut.material == 'Cerebellum White Matter', 'CT Number [HU]'] = self.wm_HU
-
-        material_lut.loc[material_lut.material == 'Brain White Matter', 'grayscale'] = 12
-        material_lut.loc[material_lut.material == 'Brain White Matter', 'xcist material'] = 'white_matter'
-        material_lut.loc[material_lut.material == 'Brain White Matter', 'CT Number [HU]'] = self.wm_HU
-
-        material_lut.loc[material_lut.material == 'CSF Ventricles', 'grayscale'] = 6
-        material_lut.loc[material_lut.material == 'CSF Ventricles', 'xcist material'] = 'CSF'
-        material_lut.loc[material_lut.material == 'CSF Ventricles', 'CT Number [HU]'] = self.csf_HU
-
-        material_lut.loc[material_lut.material == 'CSF General', 'grayscale'] = 32
-        material_lut.loc[material_lut.material == 'CSF General', 'xcist material'] = 'CSF'
-        material_lut.loc[material_lut.material == 'CSF General', 'CT Number [HU]'] = self.csf_HU
-
-        # BONE
-        material_lut.loc[material_lut.material == 'Skull', 'grayscale'] = 40
-        material_lut.loc[material_lut.material == 'Skull', 'xcist material'] = 'ncat_skull'
-        material_lut.loc[material_lut.material == 'Skull', 'CT Number [HU]'] = 900
-
-        material_lut.loc[material_lut.material == 'Skull Diplo', 'grayscale'] = 52
-        material_lut.loc[material_lut.material == 'Skull Diplo', 'xcist material'] = 'ncat_skull'
-        material_lut.loc[material_lut.material == 'Skull Diplo', 'CT Number [HU]'] = 800 # https://en.wikipedia.org/wiki/Diplo%C3%AB
-
-        material_lut.loc[material_lut.material == 'Skull Inner Table', 'grayscale'] = 53
-        material_lut.loc[material_lut.material == 'Skull Inner Table', 'xcist material'] = 'ncat_skull'
-        material_lut.loc[material_lut.material == 'Skull Inner Table', 'CT Number [HU]'] = 1000
-
-        material_lut.loc[material_lut.material == 'Skull Outer Table', 'grayscale'] = 54
-        material_lut.loc[material_lut.material == 'Skull Outer Table', 'xcist material'] = 'ncat_skull'
-        material_lut.loc[material_lut.material == 'Skull Outer Table', 'CT Number [HU]'] = 1000
-
-        # OTHER TISSUES
-        material_lut.loc[material_lut.material == 'Adipose Tissue', 'grayscale'] = 43
-        material_lut.loc[material_lut.material == 'Adipose Tissue', 'CT Number [HU]'] = -120
-
-        material_lut.loc[material_lut.material == 'Epidermis/Dermis', 'grayscale'] = 51
-        material_lut.loc[material_lut.material == 'Epidermis/Dermis', 'CT Number [HU]'] = 50
-
-        material_lut.loc[material_lut.material == 'Subcutaneous Adipose Tissue', 'grayscale'] = 62
-        material_lut.loc[material_lut.material == 'Subcutaneous Adipose Tissue', 'CT Number [HU]'] = -120
-
-        material_lut.loc[material_lut.material == 'Muscle (General)', 'grayscale'] = 63
-        material_lut.loc[material_lut.material == 'Muscle (General)', 'CT Number [HU]'] = 55
-
-        # AIR
-        material_lut.loc[material_lut.material == 'Air Internal - Ethmoidal Sinus', 'grayscale'] = 26
-        material_lut.loc[material_lut.material == 'Air Internal - Ethmoidal Sinus', 'CT Number [HU]'] = -1000
-
-        material_lut.loc[material_lut.material == 'Air Internal - Frontal Sinus', 'grayscale'] = 27
-        material_lut.loc[material_lut.material == 'Air Internal - Frontal Sinus', 'CT Number [HU]'] = -1000
-
-        material_lut.loc[material_lut.material == 'Air Internal - Maxillary Sinus', 'grayscale'] = 28
-        material_lut.loc[material_lut.material == 'Air Internal - Maxillary Sinus', 'CT Number [HU]'] = -1000
-
-        material_lut.loc[material_lut.material == 'Air Internal - Sphenoidal Sinus', 'grayscale'] = 29
-        material_lut.loc[material_lut.material == 'Air Internal - Sphenoidal Sinus', 'CT Number [HU]'] = -1000
-        
-        material_lut.loc[material_lut.material == 'Air Internal - Mastoid', 'grayscale'] = 30
-        material_lut.loc[material_lut.material == 'Air Internal - Mastoid', 'CT Number [HU]'] = -1000
-
-        material_lut.loc[material_lut.material == 'Air Internal - Nasal/Pharynx', 'grayscale'] = 31
-        material_lut.loc[material_lut.material == 'Air Internal - Nasal/Pharynx', 'CT Number [HU]'] = -1000
-        
-        material_lut.loc[material_lut.material == 'Air Internal - Oral Cavity', 'grayscale'] = 97
-        material_lut.loc[material_lut.material == 'Air Internal - Oral Cavity', 'CT Number [HU]'] = -1000
-
-
-        return material_lut[~material_lut['CT Number [HU]'].isna()]
+        return pd.read_csv(os.path.join(Path(__file__).parent.resolve(), 'MIDA_v1.csv'))
 
     def get_CT_number_phantom(self):
         if len(self._lesion_coords) > 0:
             return self._phantom
         phantom = self._phantom
         material_lut = self.material_lut
-        phantom[phantom == 50] = -1000  # air
-        phantom[phantom == 52] = 800 # the MIDA text file has an unknown character after "Skull Diplo" that makes the above method not work if not removed
+        # phantom[phantom == 50] = -1000  # air
+        # phantom[phantom == 52] = 800 # the MIDA text file has an unknown character after "Skull Diplo" that makes the above method not work if not removed
         
         HU_phantom = np.copy(phantom)
-        for _, row in material_lut[~material_lut['CT Number [HU]'].isna()].iterrows():
-            HU_phantom[phantom == row.grayscale] = row['CT Number [HU]']
+        # for _, row in material_lut[~material_lut['CT Number [HU]'].isna()].iterrows():
+        #     HU_phantom[phantom == row.grayscale] = row['CT Number [HU]']
+        for _, row in material_lut[~material_lut['HU'].isna()].iterrows():
+            if row['HU'] == 8888:
+                HU_phantom[phantom == row['MIDA_ID']] = self.wm_HU
+            elif row['HU'] == 9999:
+                HU_phantom[phantom == row['MIDA_ID']] = self.gm_HU
+            else:
+                HU_phantom[phantom == row['MIDA_ID']] = row['HU']
 
         return HU_phantom
 


### PR DESCRIPTION
Removed the material_LUT generated within the code and replaced it with a .csv modified from the MIDA source directory to include HU as a column. Many HU values are best guesses from literature and could be updated/improved at a later date, but for now work. I added flexible HU for WM and GM so they can still be modified on the fly with the self.wm_HU and self.gm_HU variables without changing the .csv.

Preliminary scan + reconstruction indicate better detectability compared to prior iteration. Changes to code base for this PR only affect MIDA phantom.