### PR TITLE
added get_vein_map and get_artery_map to MIDA_Head

### DIFF
--- a/src/pedsilicoICH/ground_truth_definition/MIDA_v1.csv
+++ b/src/pedsilicoICH/ground_truth_definition/MIDA_v1.csv
@@ -22,8 +22,8 @@
 21,0.890196,0.356863,0.505882,Hypothalamus,9999,
 22,0.72549,0.807843,1,Commissura (Anterior),8888,
 23,0.85098,0,0.247059,Commissura (Posterior),8888,
-24,1,0,0,Blood Arteries,37,
-25,0,0,1,Blood Veins,37,
+24,1,0,0,Blood Arteries,150,
+25,0,0,1,Blood Veins,150,
 26,0,0,0,Air Internal - Ethmoidal Sinus,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
 27,0,0,0,Air Internal - Frontal Sinus,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org
 28,0,0,0,Air Internal - Maxillary Sinus,-1000,Hounsfield unit | Radiology Reference Article | Radiopaedia.org

--- a/src/pedsilicoICH/ground_truth_definition/phantoms.py
+++ b/src/pedsilicoICH/ground_truth_definition/phantoms.py
@@ -535,6 +535,16 @@ and place in your `PHANTOM_DIRECTORY`, see `load_phantom` for more details
 
         return HU_phantom
 
+    def get_artery_map(self):
+        return self._phantom == self.material_lut[
+            self.material_lut.MIDA_material == 'Blood Arteries'
+            ].MIDA_ID.item()
+
+    def get_vein_map(self):
+        return self._phantom == self.material_lut[
+            self.material_lut.MIDA_material == 'Blood Veins'
+            ].MIDA_ID.item()
+
     def get_material_mask(self, material):
         if material not in self.materials:
             raise ValueError(f'{material} not in {self.materials.keys()}')


### PR DESCRIPTION
Deciding whether this belongs in a separate but related repository (e.g. [PedSilicoLVO fork](https://github.com/brandonjnelsonFDA/PedSilicoLVO)) as it relates to project item future idea of expanding to LVO as discussed during neurorad review #72 and many CADt devices are actually multi-CADt checking for both ICH and LVO in NCCT as these are often related.

This PR only includes two minor method additions to MIDA head:

https://github.com/DIDSR/PedSilicoICH/blob/199f64edd934f255c161b926547948579e9e336c/src/pedsilicoICH/ground_truth_definition/phantoms.py#L538

and

https://github.com/DIDSR/PedSilicoICH/blob/199f64edd934f255c161b926547948579e9e336c/src/pedsilicoICH/ground_truth_definition/phantoms.py#L543

which is easy in MIDA because these labels are provided in the[ phantom](https://github.com/DIDSR/PedSilicoICH/blob/LVO/src/pedsilicoICH/ground_truth_definition/MIDA_v1.csv) (rows 24, 25)

These methods allow us to grab masks of the veins and arteries (show below in blue and red), where we could then label the [ICA](https://radiopaedia.org/articles/internal-carotid-artery-1?lang=us), [M1, and M2](https://radiopaedia.org/articles/middle-cerebral-artery?lang=us) to generate synthetic blockages and LVOs by trimming off the branches or narrowing them at select points (this will likely be a separate project entirely)

**Axial MIP view** (arteries in red, veins in blue)
![image](https://github.com/user-attachments/assets/82561bd7-f52e-4795-a9f7-da27f2689d52)

**Coronal MIP view** (arteries in red, veins in blue)
![image](https://github.com/user-attachments/assets/8e7a6c43-b080-45bb-b9d6-131178709540)

The above images were generated in the [01 notebook](https://github.com/DIDSR/PedSilicoICH/blob/LVO/notebooks/01_ct_head_simulations.ipynb)
