### PR TITLE
batchmode config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ src/PedSilicoICH.egg-info
 tests/*.png
 lesions.png
 *.log
+*.1*
+*.2*
+*.3*
+*.4*
+*.5*
+*.6*
+*.7*
+*.8*
+*.9*

--- a/batchmode_CT_dataset_pipeline.sge
+++ b/batchmode_CT_dataset_pipeline.sge
@@ -16,7 +16,7 @@ exec 2>> $LOG_DIR/$LOGNAME
 
 echo "==== begin job $JOB_NAME ($SLURM_ARRAY_TASK_ID) at:" `date` "on host $HOSTNAME"
 
-source /home/brandon.nelson/anaconda3/envs/pedsilicoich/bin/activate
+source /home/$USER/anaconda3/envs/pedsilicoich/bin/activate
 
 START_TIME=`date +%s`
 set -x

--- a/batchmode_CT_dataset_pipeline.sge
+++ b/batchmode_CT_dataset_pipeline.sge
@@ -4,6 +4,7 @@
 export LOG_DIR=$1
 OUTPUT=$2
 CASES=$3
+CONFIG=$4
 
 mkdir -p $LOG_DIR
 mkdir -p $OUTPUT
@@ -19,7 +20,7 @@ source /home/brandon.nelson/anaconda3/envs/pedsilicoich/bin/activate
 
 START_TIME=`date +%s`
 set -x
-(pedsilicoich --output_directory $OUTPUT --desired_cases=$CASES)
+(pedsilicoich $CONFIG --output_directory $OUTPUT --desired_cases=$CASES)
 set +x
 EXIT_STATUS=$?
 END_TIME=`date +%s`

--- a/run_batchmode.sh
+++ b/run_batchmode.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
-
+CONFIG=${1: example_config.toml}
 SIM_NAME=pedsilicoICH_$(date +'%m-%d-%Y_%H-%M')
 LOG_DIR=logs/$SIM_NAME
 SAVE_DIR=/projects01/didsr-aiml/brandon.nelson/pedsilicoICH/$SIM_NAME
 
-COUNT=100
+desired_cases_line=$(grep "desired_cases=" "$CONFIG")
+COUNT=$(echo "$desired_cases_line" | sed 's/desired_cases=\([0-9]*\).*/\1/')
+
 echo Running $COUNT simulation conditions
 
 START_TASK=1
 END_TASK=$COUNT
-qsub -N $SIM_NAME -t $START_TASK-$END_TASK batchmode_CT_dataset_pipeline.sge $LOG_DIR $SAVE_DIR $COUNT
+qsub -N $SIM_NAME -t $START_TASK-$END_TASK batchmode_CT_dataset_pipeline.sge $LOG_DIR $SAVE_DIR $CONFIG

--- a/run_batchmode.sh
+++ b/run_batchmode.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-CONFIG=${1: example_config.toml}
+CONFIG=${1:-example_config.toml}
 SIM_NAME=pedsilicoICH_$(date +'%m-%d-%Y_%H-%M')
 LOG_DIR=logs/$SIM_NAME
-SAVE_DIR=/projects01/didsr-aiml/brandon.nelson/pedsilicoICH/$SIM_NAME
+SAVE_DIR=/projects01/didsr-aiml/$USER/pedsilicoICH/$SIM_NAME
 
 desired_cases_line=$(grep "desired_cases=" "$CONFIG")
 COUNT=$(echo "$desired_cases_line" | sed 's/desired_cases=\([0-9]*\).*/\1/')
@@ -11,4 +11,4 @@ echo Running $COUNT simulation conditions
 
 START_TASK=1
 END_TASK=$COUNT
-qsub -N $SIM_NAME -t $START_TASK-$END_TASK batchmode_CT_dataset_pipeline.sge $LOG_DIR $SAVE_DIR $CONFIG
+qsub -N $SIM_NAME -t $START_TASK-$END_TASK batchmode_CT_dataset_pipeline.sge $LOG_DIR $SAVE_DIR $COUNT $CONFIG

--- a/test_config.toml
+++ b/test_config.toml
@@ -8,7 +8,7 @@ desired_cases=10  # desired dataset size
 # seed=false  # seed to reproduce dataset
 
 [patient]
-age=[0, 100]  # range in yrs [min, max]
+age=[0, 10]  # range in yrs [min, max]
 
 [lesion]
 subtypes=[false, 'round', 'epidural', 'subdural']


### PR DESCRIPTION
adds config option for batchmode

low priority

but with this usage you can run

```shell
bash run_batchmode.sh
```

which will default to reading `example_config.toml`

or

```shell
bash run_batchmode.sh user_config.toml
```

extension of #97 