### PR TITLE
allow multiple scanners to be defined in input csv

### DIFF
--- a/default_study/default_study.csv
+++ b/default_study/default_study.csv
@@ -1,4 +1,3 @@
 age,scanner,kVp,mA,views,zspan,kernel,slice_thickness,intensity,volume,edema,subtype,mass_effect,global_seed,case_seed,output_directory
-9.0,Scanner_Default,120.0,200.0,100.0,"[0, 10]",standard,1,70.1202176136439,2.8495037044527542,4,IPH,True,183879,510414,default_study
-38.0,GE_Lightspeed16,120.0,200.0,100.0,"[0, 10]",standard,1,51.69585736492637,11.25240999858766,10,IPH,True,183879,500825,default_study
-9.0,Scanner_Default,120.0,200.0,100.0,"[0, 10]",standard,1,58.439038070693165,13.618962013864014,0,EDH,True,183879,919501,default_study
+9.0,GE_Lightspeed16,120.0,200.0,100.0,"[0, 10]",standard,1,70.1202176136439,2.8495037044527542,4,IPH,True,183879,510414,default_study
+9.0,GE_Lightspeed64,120.0,200.0,100.0,"[0, 10]",standard,1,70.1202176136439,2.8495037044527542,4,IPH,True,183879,510414,default_study

--- a/default_study/default_study.csv
+++ b/default_study/default_study.csv
@@ -1,4 +1,4 @@
-age,kVp,mA,views,zspan,kernel,slice_thickness,intensity,volume,edema,subtype,mass_effect,seed,output_directory
-6.5,120.0,200.0,100.0,"[0, 10]",soft,0,46.69629768762238,29.384526019898857,0,epidural,True,778259,default_study
-15.75,120.0,200.0,100.0,"[0, 10]",soft,0,45.27293521694713,4.159623610243102,0,epidural,True,778259,default_study
-15.75,120.0,200.0,100.0,"[0, 10]",soft,0,0.0,0.0,0,,True,778259,default_study
+age,scanner,kVp,mA,views,zspan,kernel,slice_thickness,intensity,volume,edema,subtype,mass_effect,global_seed,case_seed,output_directory
+9.0,Scanner_Default,120.0,200.0,100.0,"[0, 10]",standard,1,70.1202176136439,2.8495037044527542,4,IPH,True,183879,510414,default_study
+38.0,GE_Lightspeed16,120.0,200.0,100.0,"[0, 10]",standard,1,51.69585736492637,11.25240999858766,10,IPH,True,183879,500825,default_study
+9.0,Scanner_Default,120.0,200.0,100.0,"[0, 10]",standard,1,58.439038070693165,13.618962013864014,0,EDH,True,183879,919501,default_study

--- a/example_inclusion_criteria.toml
+++ b/example_inclusion_criteria.toml
@@ -20,10 +20,11 @@ volume='src/insilicoICH/distributions/BHSD_volume_distributions.csv'  # str or l
 attenuation='src/insilicoICH/distributions/BHSD_HU_distributions.csv'  # str or list
 
 [acquisition]
+scanner=['GE_Lightspeed16','Scanner_Default']
 views=[100]
 kVp=[120]
 mA=[200]
 
 [recon]
-kernel=['soft']
+kernel=['standard']
 slice_thickness=[1]

--- a/src/insilicoICH/defaults/GE_Lightspeed16
+++ b/src/insilicoICH/defaults/GE_Lightspeed16
@@ -1,0 +1,30 @@
+
+# Scanner geometry
+scanner.detectorCallback = "Detector_ThirdgenCurved" # name of function that defines the detector shape and model
+scanner.sid = 540.0                         # source-to-iso distance (in mm)
+scanner.sdd = 950.0                         # source-to-detector distance (in mm)
+scanner.detectorColsPerMod = 1              # number of detector columns per module
+scanner.detectorRowsPerMod = 16             # number of detector rows per module
+scanner.detectorColOffset = 0.0             # detector column offset relative to centered position (in detector columns)
+scanner.detectorRowOffset = 0.0             # detector row offset relative to centered position (in detector rows)
+scanner.detectorColSize = 1.0               # detector column pitch or size (in mm)
+scanner.detectorRowSize = 1.0               # detector row pitch or size (in mm)
+scanner.detectorColCount = 900              # total number of detector columns
+scanner.detectorRowCount = scanner.detectorRowsPerMod     # total number of detector rows
+scanner.detectorPrefilter = ['graphite', 1.0]  # detector filter
+
+# X-ray tube
+scanner.focalspotCallback = "SetFocalspot"  # name of function that defines the focal spot shape and model
+scanner.focalspotShape = "Uniform"          # Parameterize the model
+scanner.targetAngle = 7.0                   # target angle relative to scanner XY-plane (in degrees)
+scanner.focalspotWidth = 1.0
+scanner.focalspotLength = 1.0
+
+# Detector
+scanner.detectorMaterial = "Lumex"          # detector sensor material
+scanner.detectorDepth = 3.0                 # detector sensor depth (in mm)
+scanner.detectionCallback = "Detection_EI"  # name of function that defines the detection process (conversion from X-rays to detector signal)
+scanner.detectionGain = 17.0                # factor to convert energy to electrons (electrons / keV)
+scanner.detectorColFillFraction = 0.9       # active fraction of each detector cell in the column direction
+scanner.detectorRowFillFraction = 0.9       # active fraction of each detector cell in the row direction
+scanner.eNoise = 3500.0                     # standard deviation of Gaussian electronic noise (in electrons)

--- a/src/insilicoICH/defaults/GE_Lightspeed64
+++ b/src/insilicoICH/defaults/GE_Lightspeed64
@@ -1,0 +1,30 @@
+
+# Scanner geometry
+scanner.detectorCallback = "Detector_ThirdgenCurved" # name of function that defines the detector shape and model
+scanner.sid = 540.0                         # source-to-iso distance (in mm)
+scanner.sdd = 950.0                         # source-to-detector distance (in mm)
+scanner.detectorColsPerMod = 1              # number of detector columns per module
+scanner.detectorRowsPerMod = 64             # number of detector rows per module
+scanner.detectorColOffset = 0.0             # detector column offset relative to centered position (in detector columns)
+scanner.detectorRowOffset = 0.0             # detector row offset relative to centered position (in detector rows)
+scanner.detectorColSize = 1.0               # detector column pitch or size (in mm)
+scanner.detectorRowSize = 1.0               # detector row pitch or size (in mm)
+scanner.detectorColCount = 900              # total number of detector columns
+scanner.detectorRowCount = scanner.detectorRowsPerMod     # total number of detector rows
+scanner.detectorPrefilter = ['graphite', 1.0]  # detector filter
+
+# X-ray tube
+scanner.focalspotCallback = "SetFocalspot"  # name of function that defines the focal spot shape and model
+scanner.focalspotShape = "Uniform"          # Parameterize the model
+scanner.targetAngle = 7.0                   # target angle relative to scanner XY-plane (in degrees)
+scanner.focalspotWidth = 1.0
+scanner.focalspotLength = 1.0
+
+# Detector
+scanner.detectorMaterial = "Lumex"          # detector sensor material
+scanner.detectorDepth = 3.0                 # detector sensor depth (in mm)
+scanner.detectionCallback = "Detection_EI"  # name of function that defines the detection process (conversion from X-rays to detector signal)
+scanner.detectionGain = 17.0                # factor to convert energy to electrons (electrons / keV)
+scanner.detectorColFillFraction = 0.9       # active fraction of each detector cell in the column direction
+scanner.detectorRowFillFraction = 0.9       # active fraction of each detector cell in the row direction
+scanner.eNoise = 3500.0                     # standard deviation of Gaussian electronic noise (in electrons)

--- a/src/insilicoICH/defaults/Siemens_DefinitionFlash
+++ b/src/insilicoICH/defaults/Siemens_DefinitionFlash
@@ -1,0 +1,30 @@
+# WIP: UNCONFIRMED PARAMS ARE COMMENTED OUT
+# Scanner geometry
+#scanner.detectorCallback = "Detector_ThirdgenCurved" # name of function that defines the detector shape and model
+#scanner.sid = 540.0                         # source-to-iso distance (in mm)
+#scanner.sdd = 950.0                         # source-to-detector distance (in mm)
+scanner.detectorColsPerMod = 2              # number of detector columns per module https://marketing.webassets.siemens-healthineers.com/1800000000562372/d747caec4791/SOMATOM_Flash_1800000000562372.pdf
+scanner.detectorRowsPerMod = 128             # number of detector rows per module https://marketing.webassets.siemens-healthineers.com/1800000000562372/d747caec4791/SOMATOM_Flash_1800000000562372.pdf
+#scanner.detectorColOffset = 0.0             # detector column offset relative to centered position (in detector columns)
+#scanner.detectorRowOffset = 0.0             # detector row offset relative to centered position (in detector rows)
+#scanner.detectorColSize = 1.0               # detector column pitch or size (in mm)
+#scanner.detectorRowSize = 1.0               # detector row pitch or size (in mm)
+#scanner.detectorColCount = 900              # total number of detector columns
+#scanner.detectorRowCount = scanner.detectorRowsPerMod     # total number of detector rows
+#scanner.detectorPrefilter = ['graphite', 1.0]  # detector filter
+
+# X-ray tube
+#scanner.focalspotCallback = "SetFocalspot"  # name of function that defines the focal spot shape and model
+#scanner.focalspotShape = "Uniform"          # Parameterize the model
+#scanner.targetAngle = 7.0                   # target angle relative to scanner XY-plane (in degrees)
+#scanner.focalspotWidth = 1.0
+#scanner.focalspotLength = 1.0
+
+# Detector
+#scanner.detectorMaterial = "Lumex"          # detector sensor material (must be in material directory: /site-packages/gecatsim/material/)
+#scanner.detectorDepth = 3.0                 # detector sensor depth (in mm)
+#scanner.detectionCallback = "Detection_EI"  # name of function that defines the detection process (conversion from X-rays to detector signal)
+#scanner.detectionGain = 17.0                # factor to convert energy to electrons (electrons / keV)
+#scanner.detectorColFillFraction = 0.9       # active fraction of each detector cell in the column direction
+#scanner.detectorRowFillFraction = 0.9       # active fraction of each detector cell in the row direction
+#scanner.eNoise = 3500.0                     # standard deviation of Gaussian electronic noise (in electrons)

--- a/src/insilicoICH/image_acquisition.py
+++ b/src/insilicoICH/image_acquisition.py
@@ -118,32 +118,6 @@ _table_speed = {'Low': 26.67, 'Intermediate': 48, 'High': 64}
 class Scanner():
     """
     A class to hold CT simulation data and run simulations
-
-    :param phantom: Phantom class instance to be scanned, voxels in units of
-        approximate CT Numbers [HU], typically in python
-        coordinates (z, x, y)
-        where z is perpendicular to the axial plane made by x and y.
-        See <https://en.wikipedia.org/wiki/Hounsfield_scale>
-        for some suggested values for common materials
-
-    :param scanner_model: str, study identifier to be used for virtual identifier and DICOM header
-
-    :param studyname: str, study identifier to be saved in DICOM header
-    :param studyid: int, study identifier to be saved in DICOM header
-    :param seriesname: str, series identifier to be saved in DICOM header
-    :param seriesid: int, series identifier to be saved in DICOM header
-    :param output_dir: optional directory to save the intermediate and
-        final simulation results, defaults to current working directory
-    :param framework: Optional, CT simulation framework options
-        include `['CATSIM']`
-    :param materials: Optional dictionary of {material name: HU value},
-        used for construction volume fraction maps in XCIST,
-        see materials and thresholds from this XCIST example:
-        https://github.com/xcist/phantoms-voxelized/blob/main/DICOM_to_voxelized/DICOM_to_voxelized_example_head.cfg
-
-    :returns: None
-
-    See also <https://github.com/DIDSR/pediatricIQphantoms/blob/main/src/pediatricIQphantoms/make_phantoms.py#L19>
     """
     def __init__(self, phantom: Phantom, scanner_model: str = "Scanner_Default",
                  studyname: str = "default",
@@ -151,7 +125,31 @@ class Scanner():
                  framework: str = 'CATSIM', output_dir: str | Path = None,
                  materials: dict | None = None) -> None:
         """
-        Constructor method
+        :param phantom: Phantom class instance to be scanned, voxels in units of
+            approximate CT Numbers [HU], typically in python
+            coordinates (z, x, y)
+            where z is perpendicular to the axial plane made by x and y.
+            See <https://en.wikipedia.org/wiki/Hounsfield_scale>
+            for some suggested values for common materials
+
+        :param scanner_model: str, study identifier to be used for virtual identifier and DICOM header
+
+        :param studyname: str, study identifier to be saved in DICOM header
+        :param studyid: int, study identifier to be saved in DICOM header
+        :param seriesname: str, series identifier to be saved in DICOM header
+        :param seriesid: int, series identifier to be saved in DICOM header
+        :param output_dir: optional directory to save the intermediate and
+            final simulation results, defaults to current working directory
+        :param framework: Optional, CT simulation framework options
+            include `['CATSIM']`
+        :param materials: Optional dictionary of {material name: HU value},
+            used for construction volume fraction maps in XCIST,
+            see materials and thresholds from this XCIST example:
+            https://github.com/xcist/phantoms-voxelized/blob/main/DICOM_to_voxelized/DICOM_to_voxelized_example_head.cfg
+
+        :returns: None
+
+        See also <https://github.com/DIDSR/pediatricIQphantoms/blob/main/src/pediatricIQphantoms/make_phantoms.py#L19>
         """
         output_dir = output_dir or '.'
         output_dir = Path(output_dir) / f'{phantom.patient_name}'
@@ -165,6 +163,10 @@ class Scanner():
             img = img.numpy()
 
         self.phantom = phantom
+        available_scanners = [o.name for o in install_path.glob('defaults/*')
+                              if not str(o).endswith('.cfg')]
+        if scanner_model not in available_scanners:
+            raise ValueError(f'{scanner_model} not in {available_scanners}')
         self.scanner_model = scanner_model
         self.studyname = studyname or self.patientname
         self.studyid = studyid
@@ -312,7 +314,8 @@ class Scanner():
     def __repr__(self) -> str:
         repr = f'''
         {self.__class__} {self.seriesname}
-        Scanner: {self.framework}
+        Scanner: {self.scanner_model}
+        Simulation Platform: {self.framework}
         '''
         if self.recon is None:
             return repr

--- a/src/insilicoICH/image_acquisition.py
+++ b/src/insilicoICH/image_acquisition.py
@@ -67,6 +67,7 @@ def get_reconstructed_data(ct) -> np.ndarray:
 
 
 def initialize_xcist(ground_truth_image, spacings=(1, 1, 1),
+                     scanner_model='Scanner_Default',
                      output_dir='default', phantom_id='default',
                      materials=None):
     '''
@@ -76,11 +77,13 @@ def initialize_xcist(ground_truth_image, spacings=(1, 1, 1),
     print('Initializing Scanner object...')
     print(''.join(10*['-']))
     # load defaults
+    scanner_path=install_path/'defaults/'/scanner_model
+
     ct = xc.CatSim(install_path/'defaults/Phantom_Default',
                    install_path/'defaults/Physics_Default',
                    install_path/'defaults/Protocol_Default',
                    install_path/'defaults/Recon_Default',
-                   install_path/'defaults/Scanner_Default')
+                   scanner_path)
 
     ct.cfg.waitForKeypress = False
     ct.cfg.do_Recon = True
@@ -123,6 +126,8 @@ class Scanner():
         See <https://en.wikipedia.org/wiki/Hounsfield_scale>
         for some suggested values for common materials
 
+    :param scanner_model: str, study identifier to be used for virtual identifier and DICOM header
+
     :param studyname: str, study identifier to be saved in DICOM header
     :param studyid: int, study identifier to be saved in DICOM header
     :param seriesname: str, series identifier to be saved in DICOM header
@@ -140,7 +145,8 @@ class Scanner():
 
     See also <https://github.com/DIDSR/pediatricIQphantoms/blob/main/src/pediatricIQphantoms/make_phantoms.py#L19>
     """
-    def __init__(self, phantom: Phantom, studyname: str = "default",
+    def __init__(self, phantom: Phantom, scanner_model: str = "Scanner_Default",
+                 studyname: str = "default",
                  studyid: int = 0, seriesname: str = "default", seriesid=0,
                  framework: str = 'CATSIM', output_dir: str | Path = None,
                  materials: dict | None = None) -> None:
@@ -159,6 +165,7 @@ class Scanner():
             img = img.numpy()
 
         self.phantom = phantom
+        self.scanner_model = scanner_model
         self.studyname = studyname or self.patientname
         self.studyid = studyid
         self.seriesname = seriesname
@@ -174,6 +181,7 @@ class Scanner():
         self.zspan = 'dynamic'
 
         self.xcist = initialize_xcist(img, self.phantom.spacings,
+                                      scanner_model=self.scanner_model,
                                       output_dir=self.output_dir,
                                       phantom_id=phantom.patientid,
                                       materials=materials)
@@ -233,6 +241,7 @@ class Scanner():
         lesion_phantom.patient_name = 'lesion only'
         lesion_dir = self.output_dir / 'lesion_mask'
         lesion_only = Scanner(lesion_phantom,
+                              scanner_model=self.scanner_model,
                               materials={
                                 'ICRU_lung_adult_healthy': -1000,
                                 'water': -100},

--- a/src/insilicoICH/pipeline.py
+++ b/src/insilicoICH/pipeline.py
@@ -50,6 +50,7 @@ def insilicoich(input_csv, output_directory=None, keep_raw=False):
         patient_name = f'case_{patientid:03}'
         study = run_study(output_directory,
                           patient_name,
+                          scanner_model=str(patient['scanner']),
                           age=float(patient['age']),
                           kVp=float(patient['kVp']),
                           mA=float(patient['mA']),

--- a/src/insilicoICH/pipeline.py
+++ b/src/insilicoICH/pipeline.py
@@ -47,10 +47,16 @@ def insilicoich(input_csv, output_directory=None, keep_raw=False):
         output_directory = Path(output_directory)
         print(f'{patientid+1}/{n_params}')
 
+        # for old .csv files:
+        if 'scanner' in patient:
+            scanner_model = str(patient['scanner'])
+        else:
+            scanner_model = "Scanner_Default"
+
         patient_name = f'case_{patientid:03}'
         study = run_study(output_directory,
                           patient_name,
-                          scanner_model=str(patient['scanner']),
+                          scanner_model=scanner_model,
                           age=float(patient['age']),
                           kVp=float(patient['kVp']),
                           mA=float(patient['mA']),

--- a/src/insilicoICH/recruit_study.py
+++ b/src/insilicoICH/recruit_study.py
@@ -21,6 +21,7 @@ def recruit_patients(output_directory, views=[1000], desired_cases=1,
                                      len(LESION_TYPES)*[[0.1, 60]])),
                      attenuation=dict(zip(LESION_TYPES,
                                       len(LESION_TYPES)*[[0, 90]])),
+                     scanner='Scanner_Default',
                      kVp=[120],
                      mA=[300],
                      save_name=None,
@@ -87,6 +88,7 @@ or csv filepath')
     global_seed = random.integers(0, 1e6)
 
     params = dict(age=[],
+                  scanner=[],
                   kVp=[],
                   mA=[],
                   views=[],
@@ -139,6 +141,7 @@ or csv filepath')
             edema = random.choice(edema_list)
 
         params['age'].append(float(random.choice(ages)))
+        params['scanner'].append(random.choice(scanner))
         params['kVp'].append(float(random.choice(kVp_list)))
         params['mA'].append(float(random.choice(mA_list)))
         params['views'].append(float(random.choice(views)))

--- a/src/insilicoICH/study.py
+++ b/src/insilicoICH/study.py
@@ -181,7 +181,7 @@ class Study:
         return self
 
 
-def run_study(output_directory=None, patient_name='default', age=38, kVp=120,
+def run_study(output_directory=None, patient_name='default', scanner_model='Scanner_Default', age=38, kVp=120,
               mA=200, intensity=200, volume=5, lesion_type=None,
               mass_effect=True, add_positioning_augmentation=True,
               views=1000, zspan='dynamic', kernel='standard',
@@ -206,7 +206,7 @@ def run_study(output_directory=None, patient_name='default', age=38, kVp=120,
                                mode='nearest')
         phantom.apply_transform(transform, seed=seed)
 
-    scanner = Scanner(phantom, output_dir=output_directory)
+    scanner = Scanner(phantom, scanner_model=scanner_model, output_dir=output_directory)
     study = Study(scanner, 'pilot')
     study.run_study(kVp=kVp, mA=mA, views=views, zspan=zspan,
                     kernel=kernel, slice_thickness=slice_thickness)


### PR DESCRIPTION
1. new scanner field in .toml (for use by `recruit` CLI tool), as with other params multiple scanners can be defined to be randomly sampled: `scanner=['scanner1', 'scanner2', 'scanner3']`. 
2. new scanner field in input csv (generated by `recruit` CLI tool).
3. `src/insilicoich/defaults/` now contains scanner-specific config files (in addition to Scanner_Default which is identical to `GE_Lightspeed16`. New scanner config files can be added there.